### PR TITLE
Add DualMap support

### DIFF
--- a/examples/streamlit_app.py
+++ b/examples/streamlit_app.py
@@ -7,12 +7,22 @@ st.set_page_config(page_title="streamlit-folium documentation")
 "# streamlit-folium"
 
 with st.echo():
+
     import streamlit as st
     from streamlit_folium import folium_static
     import folium
 
+    page = st.radio(
+        'Select map type',
+        ['Single map', 'Dual map'],
+        index = 0
+        )
+
     # center on Liberty Bell
-    m = folium.Map(location=[39.949610, -75.150282], zoom_start=16)
+    if page == 'Single map':
+        m = folium.Map(location=[39.949610, -75.150282], zoom_start=16)
+    elif page == 'Dual map':
+        m = folium.plugins.DualMap(location=[39.949610, -75.150282], zoom_start=16)
 
     # add marker for Liberty Bell
     tooltip = "Liberty Bell"

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -1,6 +1,7 @@
 import os
 import streamlit.components.v1 as components
 import folium
+from folium import plugins
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
@@ -105,7 +106,14 @@ def folium_static(fig, width=700, height=500):
     # if Map, wrap in Figure
     if isinstance(fig, folium.Map):
         fig = folium.Figure().add_child(fig)
+        return components.html(
+            fig.render(), height=(fig.height or height) + 10, width=width
+            )
 
-    return components.html(
-        fig.render(), height=(fig.height or height) + 10, width=width
-    )
+    # if DualMap, get HTML representation
+    elif isinstance(fig, plugins.DualMap):
+        return components.html(
+            fig._repr_html_(), height=height + 10, width=width
+        )
+
+    


### PR DESCRIPTION
Streamlit-folium component now supports also [DualMap](https://python-visualization.github.io/folium/plugins.html#folium.plugins.DualMap) from Folium plugins.

* Add switch in streamlit-folium `__init__.py` to properly handle DualMap rendering

* Update app example adding DualMap