### PR TITLE
Add support for getting all drawn objects on the map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ package-lock.json
 
 .direnv/
 .envrc
+
+.streamlit/

--- a/examples/draw_support.py
+++ b/examples/draw_support.py
@@ -1,0 +1,14 @@
+import folium
+import streamlit as st
+from folium.plugins import Draw
+from streamlit_folium import st_folium
+
+"# Try drawing some objects and then clicking on them"
+
+m = folium.Map(location=[39.949610, -75.150282], zoom_start=5)
+
+Draw(export=False).add_to(m)
+
+output = st_folium(m, width=500, height=500)
+
+st.sidebar.write(output)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit_folium",
-    version="0.6.0alpha3",
+    version="0.6.0alpha4",
     author="Randy Zwitch",
     author_email="randy@streamlit.io",
     description="Render Folium objects in Streamlit",

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -6,7 +6,6 @@ import branca
 import folium
 import folium.plugins
 import streamlit.components.v1 as components
-from folium.utilities import normalize
 from jinja2 import UndefinedError
 
 
@@ -63,7 +62,7 @@ def folium_static(fig, width=700, height=500):
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-_RELEASE = True
+_RELEASE = False
 
 if not _RELEASE:
     _component_func = components.declare_component(
@@ -119,6 +118,9 @@ def st_folium(
         m_id = get_full_id(fig)
         leaflet = leaflet.replace(m_id, "map_div")
 
+    # Get rid of the annoying popup
+    leaflet = leaflet.replace("alert(coords);", "")
+
     component_value = _component_func(
         fig=leaflet,
         id=m_id,
@@ -145,10 +147,10 @@ def generate_leaflet_string(m: folium.MacroElement, nested: bool = True) -> str:
         # Add the script for map2
         leaflet += "\n" + generate_leaflet_string(m.m2, nested=nested)
         # Add the script that syncs them together
-        leaflet += normalize(m._template.module.script(m))
+        leaflet += m._template.module.script(m)
         return leaflet
 
-    leaflet = normalize(m._template.module.script(m))
+    leaflet = m._template.module.script(m)
 
     if not nested:
         return leaflet

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -62,7 +62,7 @@ def folium_static(fig, width=700, height=500):
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-_RELEASE = False
+_RELEASE = True
 
 if not _RELEASE:
     _component_func = components.declare_component(

--- a/streamlit_folium/frontend/package.json
+++ b/streamlit_folium/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit_folium",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",
@@ -14,6 +14,7 @@
     "event-target-shim": "^5.0.1",
     "hoist-non-react-statics": "^3.3.2",
     "leaflet": "^1.7.1",
+    "leaflet-draw": "^1.0.2",
     "leaflet.sync": "^0.2.4",
     "react-scripts": "^4.0.0",
     "streamlit-component-lib": "^1.3.0",
@@ -43,6 +44,7 @@
   },
   "homepage": ".",
   "devDependencies": {
+    "@types/leaflet-draw": "^1.0.5",
     "@types/underscore": "^1.11.4"
   }
 }

--- a/streamlit_folium/frontend/public/index.html
+++ b/streamlit_folium/frontend/public/index.html
@@ -11,6 +11,8 @@
   <script src="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.7.1/dist/leaflet.css">
   <script src="https://cdn.jsdelivr.net/gh/jieter/Leaflet.Sync/L.Map.Sync.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css">
   <style>
     .float-container {
       padding: 20px;

--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -1,7 +1,5 @@
 import { Streamlit, RenderData } from "streamlit-component-lib"
 import { debounce } from "underscore";
-//import "leaflet-draw";
-import * as L from "leaflet";
 
 let map: any = null;
 


### PR DESCRIPTION
<img width="1739" alt="image" src="https://user-images.githubusercontent.com/4040678/153675392-f8bae894-8689-4eed-a494-d8512e8b6c89.png">

This adds two new entries to the exported json -- all_drawings and latest_active_drawing (either clicked or drawn).