### PR TITLE
Remove extra requirements and change year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2021 Randy Zwitch
+Copyright (c) 2020-2022 Randy Zwitch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-streamlit>=1.2.0
-folium>=0.11
-jinja2
-branca


### PR DESCRIPTION
Extra requirements.txt file was from when Streamlit Cloud didn't support subfolders for requirements. Updated license to current year.