### PR TITLE
Fix safari

### DIFF
--- a/streamlit_folium/frontend/public/index.html
+++ b/streamlit_folium/frontend/public/index.html
@@ -89,6 +89,14 @@
       width: 50%;
       float: left;
     }
+
+    .hidddde {
+      height: 1px;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      #display: block;
+    }
   </style>
 </head>
 
@@ -105,7 +113,7 @@
       </div>
     </div>
   </div>
-  </div>
+  <span>&nbsp;</span>
   <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/streamlit_folium/frontend/public/index.html
+++ b/streamlit_folium/frontend/public/index.html
@@ -89,14 +89,6 @@
       width: 50%;
       float: left;
     }
-
-    .hidddde {
-      height: 1px;
-      margin: 0;
-      padding: 0;
-      overflow: hidden;
-      #display: block;
-    }
   </style>
 </head>
 


### PR DESCRIPTION
Apparently Safari is unhappy with rendering an empty iframe, even if that iframe eventually gets populated, which is why with draw(export=True) it works, because it adds a single link below the map with "Export". This adds a single space to the bottom, and it works. Probably going to mess up your pixel tests again :)