### PR TITLE
Dont fail on bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit_folium",
-    version="0.6.11",
+    version="0.6.12",
     author="Randy Zwitch",
     author_email="randy@streamlit.io",
     description="Render Folium objects in Streamlit",

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -146,6 +146,11 @@ def st_folium(
             },
         }
 
+    try:
+        bounds = fig.get_bounds()
+    except AttributeError:
+        bounds = [[None, None], [None, None]]
+
     component_value = _component_func(
         fig=leaflet,
         id=m_id,
@@ -157,7 +162,7 @@ def st_folium(
             "last_object_clicked": None,
             "all_drawings": None,
             "last_active_drawing": None,
-            "bounds": bounds_to_dict(fig.get_bounds()),
+            "bounds": bounds_to_dict(bounds),
             "zoom": fig.options.get("zoom") if hasattr(fig, "options") else {},
             "last_circle_radius": None,
             "last_circle_polygon": None,


### PR DESCRIPTION
This is specifically to handle https://github.com/python-visualization/folium/issues/1599, which may get fixed eventually, but since this is just providing a sensible initial value, it doesn't seem too critical if there are edge cases where it ends up with Nones (which is the behavior you would get if you put an empty map).