### PR TITLE
Force the example app to use the latest release

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,3 +1,3 @@
 streamlit==1.11.1
-streamlit-folium>=0.6.9
+streamlit-folium>=0.7.0
 requests


### PR DESCRIPTION
The example app is still running 0.6.9, and so failing