### PR TITLE
Use render() in main only once

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -105,7 +105,6 @@ def folium_static(
 
 def _get_siblings(fig: folium.MacroElement) -> str:
     """Get the html for any siblings of the map"""
-    fig.render()
     children = list(fig.get_root()._children.values())
 
     html = ""
@@ -127,8 +126,6 @@ def get_full_id(m: folium.MacroElement) -> str:
 
 
 def _get_map_string(fig: folium.Map) -> str:
-    fig.render()
-
     leaflet = generate_leaflet_string(fig)
 
     # Get rid of the annoying popup
@@ -242,6 +239,8 @@ def st_folium(
     # this assumes that a map is the first child
     if not (isinstance(fig, folium.Map) or isinstance(fig, folium.plugins.DualMap)):
         folium_map = list(fig._children.values())[0]
+
+    folium_map.render()
 
     leaflet = _get_map_string(folium_map)  # type: ignore
 


### PR DESCRIPTION
This PR fixes https://github.com/randyzwitch/streamlit-folium/issues/143
-> fig.render is removed in _get_map_string and _get_siblings to avoid redundancy.


Note : performance gain to have the map depicted on my use case (with st.profiler) : from 40sec to 25sec. (almost 40%)