### PR TITLE
bump node to current LTS & adapt build accordingly

### DIFF
--- a/.github/workflows/publish_PYPI_each_tag.yml
+++ b/.github/workflows/publish_PYPI_each_tag.yml
@@ -21,7 +21,7 @@ jobs:
     - name: install node
       uses: actions/setup-node@v3
       with:
-          node-version: 16
+          node-version: 20
 #       run: |
 #         sudo apt install nodejs npm
 #         npm --version

--- a/.github/workflows/run_tests_each_PR.yml
+++ b/.github/workflows/run_tests_each_PR.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - name: build streamlit-folium JS
         run: |
           cd streamlit_folium/frontend/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.13.0
-folium>=0.13
+folium>=0.13,<0.15
 jinja2
 branca
 geopandas

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.8",
-    install_requires=["streamlit>=1.13.0", "folium>=0.13", "jinja2", "branca"],
+    install_requires=["streamlit>=1.13.0", "folium>=0.13,<0.15", "jinja2", "branca"],
 )

--- a/streamlit_folium/frontend/package.json
+++ b/streamlit_folium/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit_folium",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",
@@ -16,9 +16,9 @@
     "leaflet": "^1.7.1",
     "leaflet-draw": "^1.0.2",
     "leaflet.sync": "^0.2.4",
-    "react-scripts": "^4.0.0",
-    "streamlit-component-lib": "^1.3.0",
-    "typescript": "~3.8.0",
+    "react-scripts": "^5.0.1",
+    "streamlit-component-lib": "^2.0.0",
+    "typescript": "^4",
     "underscore": "^1.13.2"
   },
   "scripts": {
@@ -44,7 +44,7 @@
   },
   "homepage": ".",
   "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@babel/plugin-transform-private-property-in-object": "^7.21.11",
     "@types/leaflet-draw": "^1.0.5",
     "@types/underscore": "^1.11.4"
   }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
-streamlit>1.11.1
+streamlit>=1.13.0
 pytest>=7.1.2
-folium>=0.13
+folium>=0.13,<0.15
 pytest-playwright
 pytest-rerunfailures
 geopandas


### PR DESCRIPTION
This fix https://github.com/randyzwitch/streamlit-folium/issues/127

The main blocker was streamlit-component-lib not upgrading to v2