### PR TITLE
Allow v0.15.1 of Folium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-streamlit>=1.13.0,!=0.15.0
-folium>=0.13
+streamlit>=1.13.0
+folium>=0.13,!=0.15.0
 jinja2
 branca
 geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.13.0
+streamlit>=1.13.0,!=0.15.0
 folium>=0.13
 jinja2
 branca

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.13.0
-folium>=0.13,<0.15
+folium>=0.13
 jinja2
 branca
 geopandas

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit_folium",
-    version="0.16.0",
+    version="0.16.1",
     author="Randy Zwitch",
     author_email="rzwitch@gmail.com",
     description="Render Folium objects in Streamlit",

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.8",
-    install_requires=["streamlit>=1.13.0", "folium>=0.13,<0.15", "jinja2", "branca"],
+    install_requires=["streamlit>=1.13.0", "folium>=0.13", "jinja2", "branca"],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.8",
-    install_requires=["streamlit>=1.13.0", "folium>=0.13", "jinja2", "branca"],
+    install_requires=["streamlit>=1.13.0", "folium>=0.13,!=0.15.0", "jinja2", "branca"],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 streamlit>=1.13.0
 pytest>=7.1.2
-folium>=0.13
+folium>=0.13,!=0.15.0
 pytest-playwright
 pytest-rerunfailures
 geopandas

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 streamlit>=1.13.0
 pytest>=7.1.2
-folium>=0.13,<0.15
+folium>=0.13
 pytest-playwright
 pytest-rerunfailures
 geopandas

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,12 +4,14 @@ def test_map():
     from streamlit_folium import _get_map_string
 
     map = folium.Map()
+    map.render()
+
     leaflet = _get_map_string(map)
     assert (
         """var map_div = L.map(
     "map_div",
     {
-        center: [0, 0],
+        center: [0.0, 0.0],
         crs: L.CRS.EPSG3857,
         zoom: 1,
         zoomControl: true,
@@ -21,7 +23,7 @@ def test_map():
 
     assert "var tile_layer_div_0 = L.tileLayer(" in leaflet
 
-    assert ").addTo(map_div);" in leaflet
+    assert ".addTo(map_div);" in leaflet
 
 
 def test_layer_control():
@@ -48,11 +50,11 @@ def test_draw_support():
     map.render()
     leaflet = _get_map_string(map)
     assert "map_div.on(L.Draw.Event.CREATED, function(e) {" in leaflet
-    assert "drawnItems.addLayer(layer);" in leaflet
+    assert "drawnItems_draw_control_div_1.addLayer(layer);" in leaflet
 
     assert (
         """map_div.on('draw:created', function(e) {
-    drawnItems.addLayer(e.layer);
+    drawnItems_draw_control_div_1.addLayer(e.layer);
 });"""
         in leaflet
     )


### PR DESCRIPTION
If I'm thinking about this correctly @blackary, we don't need to exclude 0.15.0 per se, since the solver should always go to the patch version. Thus, we can keep the requirements much looser.

If you disagree, then make a commit here. Otherwise, we'll put out a new version of streamlit-folium as well.

References #148 