### PR TITLE
Fix map center and zoom map update

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -16,7 +16,7 @@ from jinja2 import UndefinedError
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-_RELEASE = False
+_RELEASE = True
 
 if not _RELEASE:
     _component_func = components.declare_component(

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -16,7 +16,7 @@ from jinja2 import UndefinedError
 
 # Create a _RELEASE constant. We'll set this to False while we're developing
 # the component, and True when we're ready to package and distribute it.
-_RELEASE = True
+_RELEASE = False
 
 if not _RELEASE:
     _component_func = components.declare_component(

--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -269,17 +269,27 @@ function onRender(event: Event): void {
     }
   }
 
+  var view_changed = false
+  var new_zoom = window.map.getZoom()
   if (zoom && zoom !== window.__GLOBAL_DATA__.last_zoom) {
-    window.map.setZoom(zoom)
+    new_zoom = zoom
     window.__GLOBAL_DATA__.last_zoom = zoom
+    view_changed = true
   }
+
+  var new_center = window.map.getCenter()
   if (
     center &&
     JSON.stringify(center) !==
       JSON.stringify(window.__GLOBAL_DATA__.last_center)
   ) {
-    window.map.panTo(center)
+    new_center = center
     window.__GLOBAL_DATA__.last_center = center
+    view_changed = true
+  }
+
+  if (view_changed) {
+    window.map.setView(new_center, new_zoom)
   }
 }
 


### PR DESCRIPTION
Fixes #154.

@blackary the solution you proposed in #154 to change the widget key works, but it triggers a widget reloading (map quickly disappearing and appearing again). This can be avoided by using setView instead of manually setting the zoom and the center separately (see [leafleat issue 170](https://github.com/vue-leaflet/Vue2Leaflet/issues/170#issuecomment-389442828).

I couldn't add tests since (to the best of my knowledge) playwright doesn't allow to interact with the map (change center and zoom). But you can test it on your side with the same sample code as in #154 and it works fine.

Tests were passing on my side.
