### PR TITLE
Added link to JS for realtime

### DIFF
--- a/streamlit_folium/frontend/public/index.html
+++ b/streamlit_folium/frontend/public/index.html
@@ -51,6 +51,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-locatecontrol/0.66.2/L.Control.Locate.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/leaflet.vectorgrid@1.3.0/dist/Leaflet.VectorGrid.bundled.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-groupedlayercontrol/0.6.1/leaflet.groupedlayercontrol.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-realtime/2.2.0/leaflet-realtime.js"></script>
 
     <link
       rel="stylesheet"


### PR DESCRIPTION
Closes #174.

I am a contributing developer of Folium and the developer of the Folium realtime plugin. Great work on streamlit-folium! I use Folium mainly from streamlit, so your package is really useful to me.

To fix the issue I added a link to the javascript file for realtime plugin to the component's public/index.html. I am curious though if streamlit-folium could not be changed to generate these links based on the Folium generated map. We are updating the Folium code base so that users can and and override javascript and css files at runtime. This would break the currently hardcoded list of javascript and css links. 

The Folium generated code contains links to include the required javascript and css files. Is there some way these could be included in the generated code?

