### PR TITLE
Exclude streamlit version 1.34 from requirements

### DIFF
--- a/.github/workflows/run_tests_each_PR.yml
+++ b/.github/workflows/run_tests_each_PR.yml
@@ -3,7 +3,11 @@
 
 name: Run tests each PR
 
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/run_tests_each_PR.yml
+++ b/.github/workflows/run_tests_each_PR.yml
@@ -3,11 +3,7 @@
 
 name: Run tests each PR
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: push
 
 jobs:
   build:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.13.0
+streamlit>=1.13.0,!=1.34.0
 pytest>=7.1.2
 folium>=0.13,!=0.15.0
 pytest-playwright


### PR DESCRIPTION
It breaks the automated tests.

The test_package.py and test_release.py fail with error message: "RuntimeError: Runtime hasn't been created!"

Reverting to Streamlit 1.33 solved the issue.

