### PR TITLE
Fix dynamic JS import and add missing scripts for colormaps

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -5,7 +5,7 @@ import os
 import re
 import warnings
 from textwrap import dedent
-from typing import Iterable
+from typing import Iterable, List
 
 import branca
 import folium
@@ -23,7 +23,7 @@ if not _RELEASE:
     _component_func = components.declare_component(
         "st_folium", url="http://localhost:3001"
     )
-    
+
 else:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend/build")
@@ -380,17 +380,19 @@ def st_folium(
             for child in fig._children.values():
                 yield from walk(child)
 
-    css_links = []
-    js_links = []
+    css_links: List[str] = []
+    js_links: List[str] = []
 
     for elem in walk(folium_map):
         if isinstance(elem, branca.colormap.ColorMap):
             # manually add d3.js
-            js_links.insert(0, "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js")
+            js_links.insert(
+                0, "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"
+            )
             js_links.insert(0, "https://d3js.org/d3.v4.min.js")
         css_links.extend([href for _, href in elem.default_css])
         js_links.extend([src for _, src in elem.default_js])
-    
+
     component_value = _component_func(
         script=leaflet,
         html=html,

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -5,7 +5,7 @@ import os
 import re
 import warnings
 from textwrap import dedent
-from typing import Iterable, List
+from typing import Iterable
 
 import branca
 import folium
@@ -380,8 +380,8 @@ def st_folium(
             for child in fig._children.values():
                 yield from walk(child)
 
-    css_links: List[str] = []
-    js_links: List[str] = []
+    css_links: list[str] = []
+    js_links: list[str] = []
 
     for elem in walk(folium_map):
         if isinstance(elem, branca.colormap.ColorMap):

--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -256,10 +256,44 @@ async function onRender(event: Event) {
       window.__GLOBAL_DATA__.last_layer_control = layer_control
 
       if (feature_group) {
-        // render feature group
-        console.log("Rendering feature group...")
-        eval(feature_group)
+        // eslint-disable-next-line
+        eval(feature_group + layer_control)
+        for (let key in window.map._layers) {
+          let layer = window.map._layers[key]
+          layer.off("click", onLayerClick)
+          layer.on("click", onLayerClick)
+          if (return_on_hover) {
+            layer.off("mouseover", onLayerClick)
+            layer.on("mouseover", onLayerClick)
+          }
+        }
+      } else {
+        // eslint-disable-next-line
+        eval(layer_control)
       }
+    }
+
+    var view_changed = false
+    var new_zoom = window.map.getZoom()
+    if (zoom && zoom !== window.__GLOBAL_DATA__.last_zoom) {
+      new_zoom = zoom
+      window.__GLOBAL_DATA__.last_zoom = zoom
+      view_changed = true
+    }
+
+    var new_center = window.map.getCenter()
+    if (
+      center &&
+      JSON.stringify(center) !==
+        JSON.stringify(window.__GLOBAL_DATA__.last_center)
+    ) {
+      new_center = center
+      window.__GLOBAL_DATA__.last_center = center
+      view_changed = true
+    }
+
+    if (view_changed) {
+      window.map.setView(new_center, new_zoom)
     }
   }
 


### PR DESCRIPTION
This PR addresses several issues related to dynamic JavaScript packages imports and the not displayed colormap.

1. JavaScript package loading order
The script loading mechanism in `index.tsx` has been modified to ensure that JavaScript packages are imported sequentially. This should fix the issues with the vanishing overlay and feature groups caused by dependencies not being loaded in the correct order.

2. Colormap display
The `d3` package, required for displaying the `colormap`, has been manually included. The previous dynamic JS and CSS dependency detection in `__init__.py` did not work for `branca.colormap.ColorMap` objects, leading to the colormap not being displayed.

With these changes, the dynamic package loading and colormap display issues should be resolved.