### PR TITLE
add font-size to html tag to avoid conflict with bootstrap css

### DIFF
--- a/streamlit_folium/frontend/public/index.html
+++ b/streamlit_folium/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="font-size: 1rem;">
   <head>
     <title>Streamlit Folium Component</title>
     <meta charset="UTF-8" />


### PR DESCRIPTION
As per #204 - this fixes the issue of 7.5px font sizes in map elements.

In local testing, the issue was still present, but was coming from bootstrap.min.css rather than glyphicon-boostrap.css but the effect was the same. I don't think this fix will cause other issues as it is only setting the iframe font-size to 1rem, which should be a pretty safe default.