### PR TITLE
docs: include link to PyCafe for a live example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Currently, there are two functions defined:
 
 ## Example
 
+
+[<img src="https://py.cafe/logos/pycafe_logo.png" alt="PyCafe logo" width="24" height="24"> Run and edit this example in Py.Cafe](https://py.cafe/maartenbreddels/streamlit-folium-geospatial-visualizations)
+
 ![streamlit_folium example](https://raw.githubusercontent.com/randyzwitch/streamlit-folium/master/tests/visual_baseline/test_basic/first_test/baseline.png)
 
 


### PR DESCRIPTION
Hi Randy,

I think it would be nice if people can play directly with your library on https://py.cafe
I don't know if you like that the link to the project links to a personal project of mine.
If something needs to change, you can always fork it, edit it and point to your project.

Let me know what you think.

Regards,

Maarten

Including the markdown below so you can preview it:
---

[<img src="https://py.cafe/logos/pycafe_logo.png" alt="PyCafe logo" width="24" height="24"> Run and edit this example in Py.Cafe](https://py.cafe/maartenbreddels/streamlit-folium-geospatial-visualizations)