### PR TITLE
 Fix issue with Draw Support

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -135,7 +135,7 @@ def _get_map_string(fig: folium.Map) -> str:
     leaflet = leaflet.replace("alert(coords);", "")
 
     # Rename drawnItems
-    leaflet = leaflet.replace("drawnItems_draw_control_div_1", "drawnItems")
+    leaflet = re.sub(r"drawnItems_draw_control_div_\d+", "drawnItems", leaflet)
 
     leaflet = dedent(leaflet)
 


### PR DESCRIPTION
In some cases folium generates an id for the draw control that ends in a different digit. Not sure when or why.

This change uses a regex to rename drawnItems_<suffix> to drawnItems in javascript, so it can handle both cases.

Closes issue #203