### PR TITLE
Add return values for selected layers in LayersControl

### DIFF
--- a/examples/pages/layer_control.py
+++ b/examples/pages/layer_control.py
@@ -1,79 +1,90 @@
 import folium
 import streamlit as st
-from folium.plugins import VectorGridProtobuf
+from folium.plugins import Draw
 from folium.raster_layers import WmsTileLayer
-from folium.plugins import Draw, FloatImage
-
 
 from streamlit_folium import st_folium
 
+# Set page configurations
 st.set_page_config(
     page_title="streamlit-folium documentation: LayerControl",
 )
 
-# Define WMTS layers
-LAYER_WMTS = {
+# WMTS layers dictionary
+LAYER_WMTS: dict[str, dict] = {
     "KATASTER-Farbig": {
         "wmts_url": "https://geodienste.ch/db/avc_0/deu",
         "layer_name": "daten",
-        "legend_url": None
+        "legend_url": None,
     },
     "SWISS-IMAGE": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.swisstopo.swissimage",
-        "legend_url": None
+        "legend_url": None,
     },
     "Solarenergie: Eignung Dächer": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.bfe.solarenergie-eignung-daecher",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-daecher_de.png"
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-daecher_de.png",
     },
     "Solarenergie: Eignung Fassaden": {
         "wmts_url": "https://wms.geo.admin.ch/g",
         "layer_name": "ch.bfe.solarenergie-eignung-fassaden",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-fassaden_de.png"
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-fassaden_de.png",
     },
     "Solare Einstrahlung horizontal": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.bfe.solarenergie-einstrahlung_0_grad",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_0_grad_de.png"
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_0_grad_de.png",
     },
     "Solare Einstrahlung 30° Neigung Süd": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.bfe.solarenergie-einstrahlung_30_grad",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_30_grad_de.png"
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_30_grad_de.png",
     },
     "Solare Einstrahlung 75° Neigung Süd": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.bfe.solarenergie-einstrahlung_75_grad",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_75_grad_de.png"
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_75_grad_de.png",
     },
     "Solare Einstrahlung 90° Neigung Süd": {
         "wmts_url": "https://wms.geo.admin.ch/",
         "layer_name": "ch.bfe.solarenergie-einstrahlung_90_grad",
-        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_90_grad_de.png"
-    }
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_90_grad_de.png",
+    },
 }
+
 m = folium.Map(location=[47.377512, 8.540670], zoom_start=15, max_zoom=20)
+
 selected_layers = LAYER_WMTS
-# Add selected layers to the map
+
 for i, layer in enumerate(selected_layers):
     layer_info = LAYER_WMTS[layer]
-    
-    WmsTileLayer(
-        url=layer_info["wmts_url"],
-        layers=layer_info['layer_name'],
-        name=layer,
-        fmt='image/png',
-        transparent=True,
-        overlay=True,
-        control=True,
-        version='1.3.0',
-        show=i==0,
-        max_zoom=20,
-    ).add_to(m)
+
+    st.write("Layer Info:", layer_info)
+
+    if layer_info.get("wmts_url") and layer_info.get("layer_name"):
+        try:
+            WmsTileLayer(
+                url=layer_info["wmts_url"],
+                layers=layer_info["layer_name"],
+                name=layer,
+                fmt="image/png",
+                transparent=True,
+                overlay=True,
+                control=True,
+                version="1.3.0",
+                show=i == 0,
+                max_zoom=20,
+            ).add_to(m)
+        except Exception as e:
+            st.error(f"Error adding layer {layer}: {e}")
+    else:
+        st.warning(f"Missing URL or layer for {layer}")
 
 Draw(export=True).add_to(m)
 
-folium.LayerControl(position='topright').add_to(m)
-st_folium(m)
+folium.LayerControl(position="topright").add_to(m)
+
+data = st_folium(m)
+st.write(data)

--- a/examples/pages/layer_control.py
+++ b/examples/pages/layer_control.py
@@ -1,0 +1,79 @@
+import folium
+import streamlit as st
+from folium.plugins import VectorGridProtobuf
+from folium.raster_layers import WmsTileLayer
+from folium.plugins import Draw, FloatImage
+
+
+from streamlit_folium import st_folium
+
+st.set_page_config(
+    page_title="streamlit-folium documentation: LayerControl",
+)
+
+# Define WMTS layers
+LAYER_WMTS = {
+    "KATASTER-Farbig": {
+        "wmts_url": "https://geodienste.ch/db/avc_0/deu",
+        "layer_name": "daten",
+        "legend_url": None
+    },
+    "SWISS-IMAGE": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.swisstopo.swissimage",
+        "legend_url": None
+    },
+    "Solarenergie: Eignung Dächer": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.bfe.solarenergie-eignung-daecher",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-daecher_de.png"
+    },
+    "Solarenergie: Eignung Fassaden": {
+        "wmts_url": "https://wms.geo.admin.ch/g",
+        "layer_name": "ch.bfe.solarenergie-eignung-fassaden",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-eignung-fassaden_de.png"
+    },
+    "Solare Einstrahlung horizontal": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.bfe.solarenergie-einstrahlung_0_grad",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_0_grad_de.png"
+    },
+    "Solare Einstrahlung 30° Neigung Süd": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.bfe.solarenergie-einstrahlung_30_grad",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_30_grad_de.png"
+    },
+    "Solare Einstrahlung 75° Neigung Süd": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.bfe.solarenergie-einstrahlung_75_grad",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_75_grad_de.png"
+    },
+    "Solare Einstrahlung 90° Neigung Süd": {
+        "wmts_url": "https://wms.geo.admin.ch/",
+        "layer_name": "ch.bfe.solarenergie-einstrahlung_90_grad",
+        "legend_url": "https://api3.geo.admin.ch/static/images/legends/ch.bfe.solarenergie-einstrahlung_90_grad_de.png"
+    }
+}
+m = folium.Map(location=[47.377512, 8.540670], zoom_start=15, max_zoom=20)
+selected_layers = LAYER_WMTS
+# Add selected layers to the map
+for i, layer in enumerate(selected_layers):
+    layer_info = LAYER_WMTS[layer]
+    
+    WmsTileLayer(
+        url=layer_info["wmts_url"],
+        layers=layer_info['layer_name'],
+        name=layer,
+        fmt='image/png',
+        transparent=True,
+        overlay=True,
+        control=True,
+        version='1.3.0',
+        show=i==0,
+        max_zoom=20,
+    ).add_to(m)
+
+Draw(export=True).add_to(m)
+
+folium.LayerControl(position='topright').add_to(m)
+st_folium(m)

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -278,7 +278,7 @@ def st_folium(
     #
     # "default" is a special argument that specifies the initial return
     # value of the component before the user has interacted with it.
-    
+
     if use_container_width:
         width = None
 
@@ -330,7 +330,7 @@ def st_folium(
         else {},
         "last_circle_radius": None,
         "last_circle_polygon": None,
-        "selected_layers": None
+        "selected_layers": None,
     }
 
     # If the user passes a custom list of returned objects, we'll only return those

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -19,6 +19,7 @@ from jinja2 import UndefinedError
 # the component, and True when we're ready to package and distribute it.
 _RELEASE = True
 
+
 if not _RELEASE:
     _component_func = components.declare_component(
         "st_folium", url="http://localhost:3001"
@@ -277,7 +278,8 @@ def st_folium(
     #
     # "default" is a special argument that specifies the initial return
     # value of the component before the user has interacted with it.
-
+    
+    # Define WMTS layers
     if use_container_width:
         width = None
 
@@ -329,6 +331,7 @@ def st_folium(
         else {},
         "last_circle_radius": None,
         "last_circle_polygon": None,
+        "selected_layers": None
     }
 
     # If the user passes a custom list of returned objects, we'll only return those

--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -279,7 +279,6 @@ def st_folium(
     # "default" is a special argument that specifies the initial return
     # value of the component before the user has interacted with it.
     
-    # Define WMTS layers
     if use_container_width:
         width = None
 

--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -115,13 +115,21 @@ function onDraw(e: any) {
 
 function removeLayer(e: any) {
   const global_data = window.__GLOBAL_DATA__
-  global_data.selected_layers.delete(e.layer["wmsParams"]["layers"]);
+  let layer = e.layer
+  if (layer && layer["_url"] && layer["wmsParams"] && layer["wmsParams"]["layers"]) {
+    let url_layer = `${layer["_url"]};${layer["wmsParams"]["layers"]}`;
+    global_data.selected_layers.delete(url_layer);
+}
   debouncedUpdateComponentValue(window.map)
 }
 
 function addLayer(e: any) {
   const global_data = window.__GLOBAL_DATA__
-  global_data.selected_layers.add(e.layer["wmsParams"]["layers"]);
+  let layer = e.layer
+  if (layer && layer["_url"] && layer["wmsParams"] && layer["wmsParams"]["layers"]) {
+    let url_layer = `${layer["_url"]};${layer["wmsParams"]["layers"]}`;
+    global_data.selected_layers.add(url_layer);
+  }
   debouncedUpdateComponentValue(window.map)
 }
 
@@ -186,9 +194,9 @@ window.initComponent = (map: any, return_on_hover: boolean) => {
   map.on("moveend", onMapMove)
   for (let key in map._layers) {
     let layer = map._layers[key]
-    let layer_url = layer["_url"]
-    if (typeof layer_url !== "undefined") {
-      global_data.selected_layers.add(layer_url);
+    if (layer && layer["_url"] && layer["wmsParams"] && layer["wmsParams"]["layers"]) {
+      let url_layer = `${layer["_url"]};${layer["wmsParams"]["layers"]}`;
+      global_data.selected_layers.add(url_layer);
     }
     layer.on("click", onLayerClick)
     if (return_on_hover) {


### PR DESCRIPTION
**Description:**

I primarily use st_folium in combination with LayerControl in Streamlit applications. However, one challenge I encountered is that there is no straightforward way to determine which layers are currently selected from the LayerControl. This limits functionality when trying to dynamically update components such as legends for each layer.

**Here's a basic example of the issue:**

  - The user toggles visibility of multiple layers using LayerControl.
  - There is no direct support to return the currently selected layers, which makes it difficult to update elements like legends that correspond to those layers.

To address this issue, I introduced a modification that allows st_folium to return the currently selected layers when interacting with the LayerControl. Now, when users toggle visibility of layers, the Streamlit app can respond accordingly, such as updating a legend for each selected layer. This greatly enhances interactivity.
