### PR TITLE
Prepare for 0.23.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="streamlit_folium",
-    version="0.22.1",
+    version="0.23.0",
     author="Randy Zwitch",
     author_email="rzwitch@gmail.com",
     description="Render Folium objects in Streamlit",
@@ -12,6 +12,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["streamlit>=1.13.0", "folium>=0.13,!=0.15.0", "jinja2", "branca"],
 )


### PR DESCRIPTION
Moving it up another minor version since we dropped 3.8 from the test matrix. So updated the version number and changed `python_requires`