### PR TITLE
Add a global reference to the Streamlit library

### DIFF
--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -29,6 +29,7 @@ declare global {
     drawnItems: any
     feature_group: any
     layer_control: any
+    Streamlit: any
   }
 }
 
@@ -165,6 +166,7 @@ function getPixelatedStyles(pixelated: boolean) {
   `
   return styles
 }
+window.Streamlit = Streamlit;
 
 window.initComponent = (map: any, return_on_hover: boolean) => {
   map.on("click", onMapClick)


### PR DESCRIPTION
I noticed the `Streamlit.setComponentValue()` example (in `realtime.py`) was no longer working. For some reason, in the latest releases the Streamlit library is no longer in the global namespace. This change adds it back to the window namespace, so JsCode callbacks in Folium can return values to Streamlit.

Closes #231 