### PR TITLE
Call Streamlit.setFrameHeight to set frame height correctly

### DIFF
--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -421,6 +421,7 @@ async function onRender(event: Event) {
     })
   }
   finalizeOnRender()
+  Streamlit.setFrameHeight()
 }
 
 // Attach our `onRender` handler to Streamlit's render event.

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -391,3 +391,27 @@ def test_layer_control_dynamic_update(page: Page):
         .get_by_role("img")
         .locator("path")
     ).to_be_visible()
+
+
+def test_frame_height_matches_content_height(page: Page):
+    """Make sure that the frame height matches the document height to confirm that
+    Streamlit.setFrameHeight was called correctly."""
+
+    iframe = page.get_by_test_id("stCustomComponentV1")
+    iframe_html = page.frame_locator("[data-testid=stCustomComponentV1]").locator(
+        "html"
+    )
+
+    # Wait for the iframe to load and have a height - otherwise the test will be flaky
+    page.wait_for_function(
+        "el => window.getComputedStyle(el).height !== '0px'",
+        arg=iframe.element_handle(),
+    )
+
+    # Now make sure that the heights match
+    iframe_height = iframe.evaluate("el => window.getComputedStyle(el).height")
+    iframe_html_height = iframe_html.evaluate(
+        "el => window.getComputedStyle(el).height"
+    )
+
+    assert iframe_height == iframe_html_height


### PR DESCRIPTION
Might be related to #213

It looks like the `setFrameHeight` behavior broke between versions `0.20.0` and `0.20.1` leading to too much bottom space after a map. If you take for example this app: https://github.com/danielan987/datafarm, you can see that the Selectbox element is way too far in the bottom when using a version > `0.20.0` but still works in `0.20.0`. 
The proposed fix here seems to resolve the issue. I also added an e2e test to ensure that the `iframe` height and the inner `html` height match.