### PR TITLE
add license detail to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setuptools.setup(
     author="Randy Zwitch",
     author_email="rzwitch@gmail.com",
     description="Render Folium objects in Streamlit",
+    license="MIT",
     long_description="",
     long_description_content_type="text/plain",
     url="https://github.com/randyzwitch/streamlit-folium",


### PR DESCRIPTION
While running [liccheck](https://pypi.org/project/liccheck/) streamlit-folium is flagged as an 'unknown' license. I believe this can be solved by adding the license type into setup.py. An example of this can be seen at the [folium repo](https://github.com/python-visualization/folium/blob/main/setup.py) .

Thank you for a great package!