### PR TITLE
Cleanup examples

### DIFF
--- a/examples/pages/geojson_popup.py
+++ b/examples/pages/geojson_popup.py
@@ -6,7 +6,7 @@ import geopandas
 import pandas as pd
 import requests
 import streamlit as st
-from folium.features import GeoJsonPopup, GeoJsonTooltip
+from folium import GeoJsonPopup, GeoJsonTooltip
 
 from streamlit_folium import st_folium
 

--- a/examples/pages/layer_control.py
+++ b/examples/pages/layer_control.py
@@ -1,7 +1,7 @@
 import folium
 import streamlit as st
+from folium import WmsTileLayer
 from folium.plugins import Draw
-from folium.raster_layers import WmsTileLayer
 
 from streamlit_folium import st_folium
 

--- a/examples/pages/simple_popup.py
+++ b/examples/pages/simple_popup.py
@@ -1,6 +1,6 @@
 import folium
 import streamlit as st
-from folium.features import Marker, Popup
+from folium import Marker, Popup
 
 from streamlit_folium import st_folium
 


### PR DESCRIPTION
Imports should be from `folium` or `folium.plugins` to avoid problems if folium ever refactors its inner package structure.