### PR TITLE
Deduplicate js_links

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -412,6 +412,10 @@ def st_folium(
         css_links.extend([href for _, href in getattr(elem, "default_css", [])])
         js_links.extend([src for _, src in getattr(elem, "default_js", [])])
 
+    # deduplicate links
+    css_links = list(dict.fromkeys(css_links))
+    js_links = list(dict.fromkeys(js_links))
+
     hash_key = generate_js_hash(leaflet, key, return_on_hover)
 
     def _on_change():


### PR DESCRIPTION
Displaying a st_folium map with multiple elements requiring plugin, e.g. PolyLineTextPath would add multiple duplicates of the same plugin script link causing other issues (e.g. the layer control not working properly).


For example, the legend in the following app is broken (doesn't work with st_folium but works with folium_static)
```python
import folium
import streamlit as st
from folium.plugins import PolyLineTextPath
from streamlit_folium import st_folium

st.title("Streamlit Folium Polyline Text Example")

# Create the map
m = folium.Map(location=[51.505, -0.09], zoom_start=13)


# create feature group
feature_group_a = folium.FeatureGroup(name="Polyline A").add_to(m)


# First polyline
line1 = folium.PolyLine(
    locations=[[51.505, -0.09], [51.51, -0.1], [51.52, -0.12]],
    color="blue",
    weight=5,
).add_to(feature_group_a)

# Add text along the first polyline
PolyLineTextPath(
    line1,
    " Line 1 Text → ",
    repeat=True,
    offset=7,
    attributes={"fill": "blue", "font-weight": "bold", "font-size": "12"},
).add_to(feature_group_a)


feature_group_b = folium.FeatureGroup(name="Polyline B").add_to(m)

# Second polyline
line2 = folium.PolyLine(
    locations=[[51.505, -0.08], [51.51, -0.07], [51.52, -0.06]],
    color="red",
    weight=5,
).add_to(feature_group_b)

# Add text along the second polyline
PolyLineTextPath(
    line2,
    " Line 2 Text → ",
    repeat=True,
    offset=7,
    attributes={"fill": "red", "font-weight": "bold", "font-size": "12"},
).add_to(feature_group_b)

folium.LayerControl(collapsed=False).add_to(m)

# Render the map in Streamlit
st_folium(
    m,
    width=700,
    height=500,
)
```

Adding the deduplication of js_links as in this PR fixes it.