### PR TITLE
CVE-2025-61140: Prevent prototype pollution in JSON path handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "streamlit-folium"
-version = "0.26.1"
+version = "0.26.2"
 description = "Render Folium objects in Streamlit"
 readme = "README.md"
 authors = [{ name = "Randy Zwitch", email = "rzwitch@gmail.com" }]

--- a/streamlit_folium/frontend/package.json
+++ b/streamlit_folium/frontend/package.json
@@ -44,5 +44,10 @@
     "@babel/plugin-transform-private-property-in-object": "^7.21.11",
     "@types/leaflet-draw": "^1.0.5",
     "@types/underscore": "^1.11.4"
+  },
+  "overrides": {
+    "bfj": {
+      "jsonpath": "^1.2.0"
+    }
   }
 }


### PR DESCRIPTION
A critical vulnerability was detected in the `jsonpath` dependency during  a Docker image security scanning.

The `bfj` package has [dropped support](https://gitlab.com/philbooth/bfj/-/issues/75) for `jsonpath` in the latest version while addressing this issue, so upgrading normally is not possible without breaking compatibility.

This PR adds a dependency override to apply the upstream security fix while keeping the current `bfj` integration working.

**References**:
- Fix commit: https://github.com/dchester/jsonpath/commit/9631412641b7095f86840a7a45b5b3afc68b0fcb
- CVE: 
-- https://nvd.nist.gov/vuln/detail/CVE-2025-61140 — _CVSS Version 3.x_ =>  **9.8 (Critical)**
-- https://security.snyk.io/vuln/SNYK-JS-JSONPATH-13645034 — _CVSS_  => **9.2 (Critical)**
