### PR TITLE
Add Python 3.14 to test matrix, drop 3.10 support

### DIFF
--- a/.github/workflows/run_tests_each_PR.yml
+++ b/.github/workflows/run_tests_each_PR.yml
@@ -34,7 +34,7 @@ jobs:
           npm run build
       - name: Install python dependencies
         run: |
-          uv sync --group dev --group test --no-build
+          uv sync --group dev --group test
       - name: Install playwright dependencies
         run: |
           uv run playwright install --with-deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,10 @@ dev = [
     "pre-commit",
 ]
 test = [
-    "pyproj>=3.7.1",
+    "pyproj>=3.7.2",
+    "pyogrio>=0.12.1",
+    "shapely>=2.1.2",
+    "pyarrow>=23.0.1",
     "folium>=0.13,!=0.15.0",
     "geopandas>=1.0.1",
     "pytest>=7.1.2",


### PR DESCRIPTION
Trying again to see if geopandas still needs a source build for 3.14.

As part of this update, exploring dropping Python 3.10, as it goes EOL in September 2026; even without Python 3.10 support, we will still be supporting the 4 most recent Python versions.

Fixes #283 