### PR TITLE
Add explicit read-only permission to GitHub actions

### DIFF
--- a/.github/workflows/publish_PYPI_each_tag.yml
+++ b/.github/workflows/publish_PYPI_each_tag.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
 

--- a/.github/workflows/run_tests_each_PR.yml
+++ b/.github/workflows/run_tests_each_PR.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version < '3.12'",


### PR DESCRIPTION
GitHub code scanning claims this is a medium security issue, though it's really a non-starter as the tokens referenced aren't GitHub tokens anyway.

Set to read-only for clarity.