### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/streamlit_folium/__init__.py
+++ b/streamlit_folium/__init__.py
@@ -109,7 +109,12 @@ def folium_static(
 def _get_header(fig: folium.MacroElement) -> str:
     """Get the header string for the map"""
     header = fig.get_root().header.render()
-    header = re.sub(r'<script src=".*?"></script>', "", header)
+    header = re.sub(
+        r'<script\b[^>]*\bsrc=["\'][^"\']*["\'][^>]*>.*?</script\b[^>]*>',
+        "",
+        header,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
     header = re.sub(r'<link rel="stylesheet" href=".*?"/>', "", header)
     # Fix Leaflet default marker icon path issue
     # Folium may generate incorrect imagePath missing "/images/" directory


### PR DESCRIPTION
Potential fix for [https://github.com/randyzwitch/streamlit-folium/security/code-scanning/4](https://github.com/randyzwitch/streamlit-folium/security/code-scanning/4)

In general, the problem is that the regex is trying to identify `<script>` tags but is too strict about the exact characters of the closing tag and overall tag format. To fix it, we should broaden the pattern so it matches script tags with optional whitespace before the `>`, possible attributes inside the opening tag, and a more flexible closing tag that allows whitespace and extra attributes (as browsers do). We don’t need a full HTML sanitizer here, only a more correct match for Folium’s script elements.

The best targeted fix without changing functionality is to adjust the regex on line 112 to a more flexible but still conservative pattern. Since Folium typically outputs external resource scripts (`<script src="..."></script>`), we can use a pattern like:

```python
header = re.sub(
    r'<script\b[^>]*\bsrc=["\'][^"\']*["\'][^>]*>.*?</script\b[^>]*>',
    "",
    header,
    flags=re.IGNORECASE | re.DOTALL,
)
```

This pattern:  
- Uses `<script\b` to ensure the tag name is “script”.  
- Allows arbitrary attributes and whitespace in the opening tag (`[^>]*`).  
- Requires a `src="..."` or `src='...'` attribute but tolerates other attributes around it.  
- Matches any content up to a closing `</script>` (with optional trailing attributes/whitespace) using `.*?` plus `re.DOTALL`.  
- Handles mixed case with `re.IGNORECASE`.  

This stays within `streamlit_folium/__init__.py` and uses only the already-imported `re` module. No other files need changes, and functionality remains “remove external script tags from the Folium header,” just in a more robust way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
