### PR TITLE
Fix infinite drawing geocoder issue

### DIFF
--- a/streamlit_folium/frontend/src/index.tsx
+++ b/streamlit_folium/frontend/src/index.tsx
@@ -176,13 +176,26 @@ function addLayer(e: any) {
 
 function onLayerClick(e: any) {
   const global_data = window.__GLOBAL_DATA__
-  global_data.last_object_clicked = e.latlng
+  global_data.last_object_clicked = e.latlng || null
 
+  // Extract tooltip text, guarding against layers that don't fully implement
+  // the Leaflet Layer interface (e.g. geocoder result markers).
+  // See: https://github.com/randyzwitch/streamlit-folium/issues/248
   try {
-    if (e.sourceTarget._tooltip && e.sourceTarget._tooltip._content) {
+    if (
+      e.sourceTarget &&
+      typeof e.sourceTarget.getTooltip === "function" &&
+      e.sourceTarget._tooltip &&
+      e.sourceTarget._tooltip._content
+    ) {
       let tooltip_text = extractContent(e.sourceTarget.getTooltip().getContent())
       global_data.last_object_clicked_tooltip = tooltip_text
-    } else if (e.target._tooltip && e.target._tooltip._content) {
+    } else if (
+      e.target &&
+      typeof e.target.getTooltip === "function" &&
+      e.target._tooltip &&
+      e.target._tooltip._content
+    ) {
       let tooltip_text = e.target.getTooltip().getContent()(
 	e.sourceTarget
       ).innerText
@@ -192,11 +205,22 @@ function onLayerClick(e: any) {
     console.log(error);
   }
 
+  // Extract popup text, with the same defensive guards.
   try {
-    if (e.sourceTarget._popup && e.sourceTarget._popup._content) {
+    if (
+      e.sourceTarget &&
+      typeof e.sourceTarget.getPopup === "function" &&
+      e.sourceTarget._popup &&
+      e.sourceTarget._popup._content
+    ) {
       let popup_text = e.sourceTarget.getPopup().getContent().innerText
       global_data.last_object_clicked_popup = popup_text
-    } else if (e.target._popup && e.target._popup._content) {
+    } else if (
+      e.target &&
+      typeof e.target.getPopup === "function" &&
+      e.target._popup &&
+      e.target._popup._content
+    ) {
       let popup_text = e.target.getPopup().getContent()(e.sourceTarget).innerText
       global_data.last_object_clicked_popup = popup_text
     }
@@ -205,10 +229,10 @@ function onLayerClick(e: any) {
   }
 
   let details: Array<any> = []
-  if (e.layer && e.layer.toGeoJSON) {
+  if (e.layer && typeof e.layer.toGeoJSON === "function") {
     global_data.last_active_drawing = e.layer.toGeoJSON()
   }
-  if (window.drawnItems.toGeoJSON) {
+  if (window.drawnItems && typeof window.drawnItems.toGeoJSON === "function") {
     details = window.drawnItems.toGeoJSON().features
   }
   global_data.all_drawings = details
@@ -244,7 +268,8 @@ window.initComponent = (map: any, return_on_hover: boolean) => {
   map.on("moveend", onMapMove)
   for (let key in map._layers) {
     let layer = map._layers[key]
-    if (layer && layer["_url"] && layer["wmsParams"] && layer["wmsParams"]["layers"]) {
+    if (!layer || typeof layer.on !== "function") continue
+    if (layer["_url"] && layer["wmsParams"] && layer["wmsParams"]["layers"]) {
       const layerName = layer["wmsParams"]["layers"];
       const layerUrl = layer["_url"];
 
@@ -359,6 +384,7 @@ async function onRender(event: Event) {
         eval(feature_group + layer_control)
         for (let key in window.map._layers) {
           let layer = window.map._layers[key]
+          if (!layer || typeof layer.on !== "function") continue
           layer.off("click", onLayerClick)
           layer.on("click", onLayerClick)
           if (return_on_hover) {


### PR DESCRIPTION
Fixes #248 

@hansthen You commented on this, so I'm hoping you have the proper background to review it. It's purely Claude 

## Changes made (all in `streamlit_folium/frontend/src/index.tsx`)

### `onLayerClick`
- **Guard `e.sourceTarget` and `e.target`** — check they exist before accessing properties on them
- **Check `typeof getPopup/getTooltip === "function"`** before calling — the geocoder plugin's result markers may have `_popup`/`_tooltip` properties set but lack the corresponding getter methods, causing the `Uncaught TypeError: t.sourceTarget.getPopup is not a function` error
- **Guard `e.latlng`** — draw events may not always have `latlng`; default to `null`
- **Guard `e.layer.toGeoJSON` and `window.drawnItems.toGeoJSON`** — use `typeof === "function"` checks instead of truthy checks

### `initComponent` and `finalizeOnRender`
- **Skip non-conforming layers** — added `if (!layer || typeof layer.on !== "function") continue` when iterating `map._layers` to attach click handlers. This prevents attaching handlers to geocoder internal objects that don't implement the full Leaflet Layer interface.

### Root cause

The geocoder's result marker fires click events during draw operations. The `onLayerClick` handler crashes trying to call `getPopup()` on it, and the unhandled error breaks the draw plugin's state machine — so mouse-release doesn't properly end the drawing, and a new drawing immediately starts.
